### PR TITLE
Set initial hot_score and add gradient overlay for discussion descriptions

### DIFF
--- a/src/actions/copany.actions.ts
+++ b/src/actions/copany.actions.ts
@@ -42,7 +42,7 @@ export async function createCopanyAction(
       license: null,
       cover_image_url: null,
       isDefaultUseCOSL: false,
-      hot_score: 0, // Will be calculated by trigger
+      hot_score: 100, // Initial value: avgMonthlyRevenue(0) + star_count(0) + (100 / hours_since_creation(1)) = 100
       mission: null,
       vision: null,
       distribution_delay_days: 90,

--- a/src/services/discussion.service.ts
+++ b/src/services/discussion.service.ts
@@ -81,6 +81,10 @@ export class DiscussionService {
     issue_id?: string | null;
   }): Promise<Discussion> {
     const supabase = await createSupabaseClient();
+    // Calculate initial hot_score: (vote_up_count + 1) / pow((hours_since_creation + 2), 1.5)
+    // For new discussion: vote_up_count = 0, hours_since_creation = 0
+    // hot_score = (0 + 1) / pow((0 + 2), 1.5) = 1 / pow(2, 1.5) ≈ 0.353553
+    const initialHotScore = 1 / Math.pow(2, 1.5);
     const { data, error } = await supabase
       .from("discussion")
       .insert({
@@ -90,6 +94,7 @@ export class DiscussionService {
         creator_id: input.creator_id,
         labels: input.labels ?? [],
         issue_id: input.issue_id ?? null,
+        hot_score: initialHotScore,
       })
       .select()
       .single();


### PR DESCRIPTION
**English:**

1. Set initial `hot_score` for newly created discussions and copanies
2. Add gradient overlay at the bottom of discussion descriptions when content exceeds max height (240px)

**Changes:**
- `src/actions/copany.actions.ts`: Set initial `hot_score` to 100
- `src/services/discussion.service.ts`: Calculate initial `hot_score` for new discussions
- `src/app/discussion/DiscussionView.tsx`: Add gradient overlay
- `src/app/copany/[id]/_subTabs/works/DiscussionView.tsx`: Add gradient overlay

**中文:**

1. 为新创建的讨论和公司设置初始 `hot_score`
2. 当讨论描述内容超过最大高度（240px）时，在底部添加渐变遮罩

**变更文件：**
- `src/actions/copany.actions.ts`: 设置初始 `hot_score` 为 100
- `src/services/discussion.service.ts`: 计算新讨论的初始 `hot_score`
- `src/app/discussion/DiscussionView.tsx`: 添加渐变遮罩
- `src/app/copany/[id]/_subTabs/works/DiscussionView.tsx`: 添加渐变遮罩

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize hot_score for new copanies/discussions and add a gradient overflow overlay for long discussion descriptions in list views.
> 
> - **Backend**:
>   - Initialize `hot_score` for new discussions in `src/services/discussion.service.ts` using a decay formula; set `hot_score` default to `100` for new copanies in `src/actions/copany.actions.ts`.
> - **Frontend (UI)**:
>   - Add gradient-overlay truncation for long discussion descriptions (max 240px) with height detection via `useRef`/`useEffect` in `src/app/discussion/DiscussionView.tsx` and `src/app/copany/[id]/_subTabs/works/DiscussionView.tsx`.
>   - Tweak discussion title size to `text-base` in `src/app/discussion/DiscussionView.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d313e98a216b6f7163668e4f281d4ded2806417. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->