### PR TITLE
feat: add dedicated Begin idea discussion hook for Copany cards

### DIFF
--- a/src/actions/discussion.actions.ts
+++ b/src/actions/discussion.actions.ts
@@ -59,4 +59,19 @@ export async function getDiscussionByIdAction(discussionId: string): Promise<Dis
   return DiscussionService.getById(discussionId);
 }
 
+export async function getBeginIdeaDiscussionAction(copanyId: string) {
+  try {
+    const discussion = await DiscussionService.getBeginIdeaDiscussionByCopanyId(
+      copanyId
+    );
+    return { success: true, discussion };
+  } catch (error) {
+    console.error("Error fetching Begin idea discussion:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
 

--- a/src/components/copany/CopanyGridView.tsx
+++ b/src/components/copany/CopanyGridView.tsx
@@ -3,8 +3,7 @@ import { Suspense, useRef, useEffect, useMemo, useState } from "react";
 import { Copany } from "@/types/database.types";
 import Image from "next/image";
 import { useRouter } from "@/hooks/useRouter";
-import { useDiscussions } from "@/hooks/discussions";
-import { useDiscussionLabels } from "@/hooks/discussionLabels";
+import { useBeginIdeaDiscussion } from "@/hooks/discussions";
 import MilkdownEditor from "@/components/commons/MilkdownEditor";
 import LoadingView from "@/components/commons/LoadingView";
 import { EMPTY_STRING } from "@/utils/constants";
@@ -42,25 +41,13 @@ interface CopanyCardProps {
 function CopanyCard({ copany, innerRef }: CopanyCardProps) {
   const router = useRouter();
   const isDarkMode = useDarkMode();
-  const { data: discussionsData } = useDiscussions(copany.id);
-  const { data: labels } = useDiscussionLabels(copany.id);
+  const { data: beginIdeaDiscussion } = useBeginIdeaDiscussion(copany.id);
   const { data: transactions = [], isLoading: isLoadingTransactions } =
     useTransactions(copany.id);
   const { data: appStoreFinanceData, isLoading: isLoadingAppStoreFinance } =
     useAppStoreFinance(copany.id);
   const t = useTranslations("finance");
   const tRightPanel = useTranslations("rightPanel");
-
-  // Flatten all pages of discussions
-  const discussions =
-    discussionsData?.pages.flatMap((page) => page.discussions) ?? [];
-
-  // Find the "Begin idea" discussion
-  const beginIdeaDiscussion = discussions.find((discussion) =>
-    discussion.labels.includes(
-      labels?.find((label) => label.name === "Begin idea")?.id || ""
-    )
-  );
 
   // Process finance data
   const [chartData, setChartData] = useState<ChartDataPoint[]>([]);

--- a/src/hooks/discussions.ts
+++ b/src/hooks/discussions.ts
@@ -1,6 +1,11 @@
 "use client";
 
-import { useMutation, useQueryClient, useInfiniteQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  useInfiniteQuery,
+  useQuery,
+} from "@tanstack/react-query";
 import type { Discussion } from "@/types/database.types";
 import type { PaginatedDiscussions } from "@/services/discussion.service";
 import {
@@ -9,6 +14,7 @@ import {
   updateDiscussionAction,
   deleteDiscussionAction,
   listAllDiscussionsAction,
+  getBeginIdeaDiscussionAction,
 } from "@/actions/discussion.actions";
 
 function listKey(copanyId: string) { return ["discussions", copanyId, "v2"] as const; } // v2: Added version to handle PaginatedDiscussions structure change
@@ -209,6 +215,24 @@ export function useAllDiscussions() {
     refetchInterval: 10 * 60 * 1000,
   });
 }
-
-
+ 
+export function useBeginIdeaDiscussion(
+  copanyId: string
+) {
+  return useQuery<Discussion | null, Error>({
+    queryKey: ["discussions", copanyId, "beginIdea", "v1"],
+    queryFn: async () => {
+      const result = await getBeginIdeaDiscussionAction(copanyId);
+      if (!result.success) {
+        throw new Error(
+          result.error ?? "Failed to load Begin idea discussion"
+        );
+      }
+      return result.discussion ?? null;
+    },
+    enabled: !!copanyId,
+    staleTime: 10 * 1000,
+    refetchInterval: 10 * 60 * 1000,
+  });
+}
 

--- a/src/services/discussion.service.ts
+++ b/src/services/discussion.service.ts
@@ -43,6 +43,61 @@ export class DiscussionService {
     return { discussions, hasMore };
   }
 
+  static async getBeginIdeaDiscussionByCopanyId(
+    copanyId: string
+  ): Promise<Discussion | null> {
+    const supabase = await createSupabaseClient();
+
+    // Find the "Begin idea" label for this copany
+    const { data: label, error: labelError } = await supabase
+      .from("discussion_label")
+      .select("id")
+      .eq("copany_id", copanyId)
+      .eq("name", "Begin idea")
+      .maybeSingle();
+
+    if (labelError) {
+      console.error("Error fetching Begin idea label:", labelError);
+      throw new Error(
+        `Failed to fetch Begin idea label: ${labelError.message}`
+      );
+    }
+
+    if (!label) {
+      return null;
+    }
+
+    const labelId = label.id;
+
+    // Find one discussion that has this label
+    let query = supabase
+      .from("discussion")
+      .select("*")
+      .contains("labels", [labelId])
+      .limit(1);
+
+    if (copanyId === "null") {
+      query = query.is("copany_id", null);
+    } else {
+      query = query.eq("copany_id", copanyId);
+    }
+
+    const { data, error } = await query.maybeSingle();
+
+    if (error) {
+      console.error("Error fetching Begin idea discussion:", error);
+      throw new Error(
+        `Failed to fetch Begin idea discussion: ${error.message}`
+      );
+    }
+
+    if (!data) {
+      return null;
+    }
+
+    return data as Discussion;
+  }
+
   static async get(discussionId: string, copanyId: string): Promise<Discussion> {
     const supabase = await createSupabaseClient();
     const { data, error } = await supabase

--- a/supabase/functions/monthly-distribute-calculator/index.ts
+++ b/supabase/functions/monthly-distribute-calculator/index.ts
@@ -207,7 +207,7 @@ Deno.serve(async (req) => {
         if (!allTxError && allTransactions) {
           console.log(`Total confirmed transactions found (sample of 10): ${allTransactions.length}`)
           if (allTransactions.length > 0) {
-            console.log(`Sample transaction dates: ${allTransactions.map((t: any) => `${t.occurred_at} (${t.type}: ${t.amount})`).join(', ')}`)
+            console.log(`Sample transaction dates: ${allTransactions.map((t: Pick<Transaction, 'occurred_at' | 'type' | 'amount'>) => `${t.occurred_at} (${t.type}: ${t.amount})`).join(', ')}`)
           }
         }
         
@@ -232,7 +232,7 @@ Deno.serve(async (req) => {
           
           // Find the most recent month with transactions
           if (allTransactions && allTransactions.length > 0) {
-            const transactionDates = allTransactions.map((t: any) => new Date(t.occurred_at))
+            const transactionDates = allTransactions.map((t: Pick<Transaction, 'occurred_at'>) => new Date(t.occurred_at))
             const latestDate = new Date(Math.max(...transactionDates.map((d: Date) => d.getTime())))
             const latestYear = latestDate.getUTCFullYear()
             const latestMonth = latestDate.getUTCMonth()
@@ -240,7 +240,7 @@ Deno.serve(async (req) => {
             
             // Count transactions by month
             const transactionsByMonth: Record<string, number> = {}
-            allTransactions.forEach((t: any) => {
+            allTransactions.forEach((t: Pick<Transaction, 'occurred_at'>) => {
               const txDate = new Date(t.occurred_at)
               const txYear = txDate.getUTCFullYear()
               const txMonth = txDate.getUTCMonth()

--- a/supabase/functions/sync-app-store-finance/index.ts
+++ b/supabase/functions/sync-app-store-finance/index.ts
@@ -458,6 +458,10 @@ function filterByAppSKU(
 // Get historical exchange rate to USD
 const exchangeRateCache = new Map<string, number>();
 
+interface ExchangeRateApiResponse {
+  rates?: Record<string, number>;
+}
+
 async function getHistoricalExchangeRateToUSD(
   currency: string,
   date: string
@@ -477,7 +481,7 @@ async function getHistoricalExchangeRateToUSD(
     {
       name: 'exchangerate.host',
       url: `https://api.exchangerate.host/${date}?base=USD`,
-      parse: (data: any) => {
+      parse: (data: ExchangeRateApiResponse) => {
         // exchangerate.host returns { rates: { EUR: 0.92, ... } } meaning 1 USD = 0.92 EUR
         // To convert EUR to USD, we need the inverse: 1 / 0.92 = 1.087
         const usdToCurrencyRate = data.rates?.[upperCurrency];
@@ -487,7 +491,7 @@ async function getHistoricalExchangeRateToUSD(
     {
       name: 'frankfurter.app',
       url: `https://api.frankfurter.app/${date}?from=${upperCurrency}&to=USD`,
-      parse: (data: any) => {
+      parse: (data: ExchangeRateApiResponse) => {
         // frankfurter.app returns { rates: { USD: 1.08 } } when converting from EUR to USD
         // This gives us the rate to convert from target currency to USD (already correct)
         return data.rates?.USD;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a dedicated data path for the "Begin idea" discussion and simplifies Copany card rendering.
> 
> - Adds `useBeginIdeaDiscussion` (React Query) backed by `getBeginIdeaDiscussionAction` and `DiscussionService.getBeginIdeaDiscussionByCopanyId`
> - Updates `CopanyGridView` to use the new hook (removes `useDiscussions`/`useDiscussionLabels` logic) and adjusts UI/animation to display the idea description when present
> - Minor type-safety improvements in Supabase edge functions: stricter generics in `monthly-distribute-calculator` logs and typed exchange-rate API parsing in `sync-app-store-finance`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5677972b1e05553239da1494ac426ac532343519. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->